### PR TITLE
Develop

### DIFF
--- a/Coderynx.Functional.slnx
+++ b/Coderynx.Functional.slnx
@@ -6,5 +6,7 @@
     </Folder>
     <Folder Name="/tests/">
         <Project Path="tests\Coderynx.Functional.Tests\Coderynx.Functional.Tests.csproj" Type="Classic C#"/>
+        <Project Path="tests\Coderynx.Functional.WebApi.Tests\Coderynx.Functional.WebApi.Tests.csproj"
+                 Type="Classic C#"/>
     </Folder>
 </Solution>

--- a/src/Coderynx.Functional.Orleans/Coderynx.Functional.Orleans.csproj
+++ b/src/Coderynx.Functional.Orleans/Coderynx.Functional.Orleans.csproj
@@ -19,8 +19,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.Functional" Version="1.7.11" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.2.1" />
+        <PackageReference Include="Coderynx.Functional" Version="1.7.11"/>
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.2.1"/>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.Functional.WebApi/Coderynx.Functional.WebApi.csproj
+++ b/src/Coderynx.Functional.WebApi/Coderynx.Functional.WebApi.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.Functional" Version="1.7.11" />
+        <PackageReference Include="Coderynx.Functional" Version="1.7.11"/>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.Functional.WebApi/ResultExtensions.cs
+++ b/src/Coderynx.Functional.WebApi/ResultExtensions.cs
@@ -43,7 +43,7 @@ public static class ResultExtensions
     /// <returns>An IResult representing the appropriate HTTP response based on the Result state.</returns>
     public static IResult ToHttpResult<TValue>(this Result<TValue> result, Func<TValue, object> transform)
     {
-        if (result.Value is not null)
+        if (result.Value is null)
         {
             return ToHttpResultInternal(result, null);
         }
@@ -91,6 +91,7 @@ public static class ResultExtensions
                 ErrorKind.None => "https://tools.ietf.org/html/rfc7231#section-6.5.1",
                 ErrorKind.NotFound => "https://tools.ietf.org/html/rfc7231#section-6.5.4",
                 ErrorKind.Conflict => "https://tools.ietf.org/html/rfc7231#section-6.5.8",
+                ErrorKind.InvalidInput => "https://tools.ietf.org/html/rfc7231#section-6.5.1",
                 _ => "https://tools.ietf.org/html/rfc7231#section-6.5.1"
             },
             Title = result.Error.Code,
@@ -99,6 +100,7 @@ public static class ResultExtensions
                 ErrorKind.None => StatusCodes.Status400BadRequest,
                 ErrorKind.NotFound => StatusCodes.Status404NotFound,
                 ErrorKind.Conflict => StatusCodes.Status409Conflict,
+                ErrorKind.InvalidInput => StatusCodes.Status400BadRequest,
                 _ => StatusCodes.Status500InternalServerError
             },
             Detail = result.Error.Message,

--- a/src/Coderynx.Functional.WebApi/version.json
+++ b/src/Coderynx.Functional.WebApi/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/tests/Coderynx.Functional.WebApi.Tests/Coderynx.Functional.WebApi.Tests.csproj
+++ b/tests/Coderynx.Functional.WebApi.Tests/Coderynx.Functional.WebApi.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Coderynx.Functional.WebApi\Coderynx.Functional.WebApi.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/Coderynx.Functional.WebApi.Tests/OptionExtensionsTests.cs
+++ b/tests/Coderynx.Functional.WebApi.Tests/OptionExtensionsTests.cs
@@ -1,0 +1,90 @@
+using Coderynx.Functional.Options;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Coderynx.Functional.WebApi.Tests;
+
+public sealed class OptionExtensionsTests
+{
+    [Fact]
+    public void ToHttpResult_SomeOption_ReturnsOkWithValue()
+    {
+        // Arrange
+        var testValue = "test-value";
+        var option = Option.Some(testValue);
+
+        // Act
+        var actionResult = option.ToHttpResult();
+
+        // Assert
+        Assert.IsType<Ok<string>>(actionResult);
+
+        var okResult = (Ok<string>)actionResult;
+        Assert.Equal(testValue, okResult.Value);
+    }
+
+    [Fact]
+    public void ToHttpResult_NoneOption_ReturnsNotFound()
+    {
+        // Arrange
+        var option = Option.None<string>();
+
+        // Act
+        var actionResult = option.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(404, problemResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_WithCustomTransform_ReturnsOkWithValue()
+    {
+        // Arrange
+        var testValue = "test-value";
+        var option = Option.Some(testValue);
+
+        // Act
+        var actionResult = option.ToHttpResult(value => $"{value}1");
+
+        // Assert
+        Assert.IsType<Ok<object>>(actionResult);
+
+        var okResult = (Ok<object>)actionResult;
+        Assert.Equal($"{testValue}1", okResult.Value);
+    }
+
+
+    [Fact]
+    public void ToHttpResult_WithCustomHandlers_NoneOption_CallsOnNone()
+    {
+        // Arrange
+        var option = Option.None<string>();
+
+        // Act
+        var actionResult = option.ToHttpResult(value => $"{value}1");
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(404, problemResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_NullValue_NoneOption_ReturnsNotFound()
+    {
+        // Arrange
+        var option = Option.None<object>();
+
+        // Act
+        var actionResult = option.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(404, problemResult.StatusCode);
+    }
+}

--- a/tests/Coderynx.Functional.WebApi.Tests/ResultExtensionsTests.cs
+++ b/tests/Coderynx.Functional.WebApi.Tests/ResultExtensionsTests.cs
@@ -1,0 +1,239 @@
+using Coderynx.Functional.Results;
+using Coderynx.Functional.Results.Errors;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Coderynx.Functional.WebApi.Tests;
+
+public sealed class ResultExtensionsTests
+{
+    [Fact]
+    public void ToHttpResult_SuccessResult_Created_Returns201()
+    {
+        // Arrange
+        var result = Result.Created();
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<Ok>(actionResult);
+
+        var createdResult = (Ok)actionResult;
+        Assert.Equal(200, createdResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_SuccessResult_Updated_Returns200()
+    {
+        // Arrange
+        var result = Result.Updated();
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<NoContent>(actionResult);
+
+        var okResult = (NoContent)actionResult;
+        Assert.Equal(204, okResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_SuccessResult_Deleted_Returns204()
+    {
+        // Arrange
+        var result = Result.Deleted();
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<NoContent>(actionResult);
+
+        var okResult = (NoContent)actionResult;
+        Assert.Equal(204, okResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_SuccessResult_Found_Returns200()
+    {
+        // Arrange
+        var result = Result.Found();
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<Ok>(actionResult);
+
+        var okResult = (Ok)actionResult;
+        Assert.Equal(200, okResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_SuccessResult_Accepted_Returns202()
+    {
+        // Arrange
+        var result = Result.Accepted();
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<Accepted>(actionResult);
+
+        var acceptedResult = (Accepted)actionResult;
+        Assert.Equal(202, acceptedResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_ErrorResult_NotFound_Returns404()
+    {
+        // Arrange
+        Result result = Error.NotFound("E001", "Resource not found");
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(404, problemResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_ErrorResult_InvalidInput_Returns400()
+    {
+        // Arrange
+        Result result = Error.InvalidInput("E002", "Invalid input");
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(400, problemResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_ErrorResult_Conflict_Returns409()
+    {
+        // Arrange
+        Result result = Error.Conflict("E005", "Conflict occurred");
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(409, problemResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_ErrorResult_Unexpected_Returns500()
+    {
+        // Arrange
+        Result result = Error.Unexpected("E006", "Unexpected error");
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(500, problemResult.StatusCode);
+    }
+
+    [Fact]
+    public void ToHttpResult_TypedSuccessResult_Created_ReturnsCreatedWithValue()
+    {
+        // Arrange
+        var testValue = "test-value";
+        var result = Result.Created(testValue);
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<Ok<object>>(actionResult);
+
+        var okResult = (Ok<object>)actionResult;
+        Assert.Equal(testValue, okResult.Value);
+    }
+    
+    [Fact]
+    public void ToHttpResult_ShouldReturnCreatedWithValue_WhenValueTransformationIsProvided()
+    {
+        // Arrange
+        var testValue = "test-value";
+        var result = Result.Created(testValue);
+
+        // Act
+        var actionResult = result.ToHttpResult(value => $"{value}1");
+
+        // Assert
+        Assert.IsType<Ok<object>>(actionResult);
+
+        var okResult = (Ok<object>)actionResult;
+        Assert.Equal($"{testValue}1", okResult.Value);
+    }
+
+    [Fact]
+    public void ToHttpResult_TypedSuccessResult_Found_ReturnsOkWithValue()
+    {
+        // Arrange
+        var testValue = new { Id = 1, Name = "Test" };
+        var result = Result.Found(testValue);
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<Ok<object>>(actionResult);
+
+        var okResult = (Ok<object>)actionResult;
+        Assert.Equal(testValue, okResult.Value);
+    }
+
+    [Fact]
+    public void ToHttpResult_TypedErrorResult_NotFound_ReturnsNotFoundWithMessage()
+    {
+        // Arrange
+        Result result = Error.NotFound("E001", "Resource not found");
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(404, problemResult.StatusCode);
+        Assert.Equal("E001", problemResult.ProblemDetails.Title);
+        Assert.Equal("Resource not found", problemResult.ProblemDetails.Detail);
+    }
+
+    [Fact]
+    public void ToHttpResult_TypedErrorResult_InvalidInput_ReturnsBadRequestWithMessage()
+    {
+        // Arrange
+        Result result = Error.InvalidInput("E002", "Invalid input provided");
+
+        // Act
+        var actionResult = result.ToHttpResult();
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(actionResult);
+
+        var problemResult = (ProblemHttpResult)actionResult;
+        Assert.Equal(400, problemResult.StatusCode);
+        Assert.Equal("E002", problemResult.ProblemDetails.Title);
+        Assert.Equal("Invalid input provided", problemResult.ProblemDetails.Detail);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test project for the `Coderynx.Functional.WebApi` package and improves the handling of HTTP results for functional result types. It adds comprehensive unit tests for both `Result` and `Option` extension methods, fixes a logic bug in the result-to-HTTP mapping, and ensures proper HTTP status codes and problem details are returned for different error kinds. The package version is also incremented for release.

**Testing and Project Structure:**

* Added a new test project `Coderynx.Functional.WebApi.Tests` targeting .NET 9, including dependencies for xUnit and code coverage, and registered it in the solution file. [[1]](diffhunk://#diff-8d117b98a6fc825c7cfc70ff5179a6696ce08e095a5f1a7a267805e16b7ebd9eR1-R32) [[2]](diffhunk://#diff-9ae18f07a84e4d36c954be4c7f711c06b7f5dcfde0cf787268038a963620f3dbR9-R10)
* Implemented extensive unit tests for `ResultExtensions` and `OptionExtensions`, covering all major success and error scenarios for HTTP result mapping. [[1]](diffhunk://#diff-e139d9b4fc7e726e102c6cce2e4c02ad985e6e26d3d6af077c34a59444783cadR1-R239) [[2]](diffhunk://#diff-8ad4951e8e902f85bd2aef4ed9bf829b1698a70a5275f20cba5c51fe454fad12R1-R90)

**Bug Fixes and Improvements in HTTP Result Mapping:**

* Fixed a logic bug in `ToHttpResult<TValue>` where the check for `result.Value` was inverted, ensuring correct HTTP responses for null and non-null values.
* Improved error handling by mapping `ErrorKind.InvalidInput` to the appropriate RFC link and HTTP 400 status code in problem responses. [[1]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dR94) [[2]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dR103)

**Versioning:**

* Bumped the package version from 1.4.1 to 1.4.2 to reflect these changes.