### PR TITLE
Develop

### DIFF
--- a/src/Coderynx.Functional.WebApi/ResultExtensions.cs
+++ b/src/Coderynx.Functional.WebApi/ResultExtensions.cs
@@ -29,7 +29,7 @@ public static class ResultExtensions
     /// <returns>An IResult representing the appropriate HTTP response based on the Result state.</returns>
     public static IResult ToHttpResult<TValue>(this Result<TValue> result)
     {
-        return result.Value is not null
+        return result.Success.Value is not null
             ? ToHttpResultInternal(result, result.Value)
             : ToHttpResultInternal(result, null);
     }
@@ -43,13 +43,12 @@ public static class ResultExtensions
     /// <returns>An IResult representing the appropriate HTTP response based on the Result state.</returns>
     public static IResult ToHttpResult<TValue>(this Result<TValue> result, Func<TValue, object> transform)
     {
-        if (result.Value is null)
+        if (result.Success.Value is null)
         {
             return ToHttpResultInternal(result, null);
         }
 
         var transformerResult = transform(result.Value);
-
         return ToHttpResultInternal(result, transformerResult);
     }
 

--- a/src/Coderynx.Functional.WebApi/version.json
+++ b/src/Coderynx.Functional.WebApi/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request makes a minor update to the `ResultExtensions` logic in the `Coderynx.Functional.WebApi` project, ensuring that HTTP result conversion checks use the correct property, and bumps the package version.

Improvements to HTTP result conversion:

* Updated `ToHttpResult` and `ToHttpResult<TValue>` methods in `ResultExtensions.cs` to check `result.Success.Value` instead of `result.Value` when determining whether to return a transformed HTTP result. This ensures the correct property is used for success checks. [[1]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dL32-R32) [[2]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dL46-L52)

Versioning:

* Incremented the version in `version.json` from `1.4.2` to `1.4.3` to reflect these changes.