### PR TITLE
Develop

### DIFF
--- a/src/Coderynx.Functional.WebApi/version.json
+++ b/src/Coderynx.Functional.WebApi/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request refactors the way HTTP results are generated from `Result` objects in the `ResultExtensions` class, improving code clarity and separation of concerns. The main change is replacing the internal helper method with more explicit methods for handling success and error cases, making the code easier to read and maintain. The package version is also incremented.

### Refactoring HTTP result generation

* Replaced the internal `ToHttpResultInternal` helper with two explicit methods: `ToHttpSuccessResult` for successful results and `ToHttpErrorResult` for failures, simplifying the logic in `ToHttpResult` overloads. [[1]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dL21-R23) [[2]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dL32-R44) [[3]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dR56-R70) [[4]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dL76-R83)
* Updated all `ToHttpResult` overloads to use the new explicit methods, ensuring failures are handled by `ToHttpErrorResult` and successes by `ToHttpSuccessResult`. [[1]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dL21-R23) [[2]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dL32-R44) [[3]](diffhunk://#diff-e3c91ff0123d0d5bbe27d8371e63c0498220d47dbb4cfb18e730dd02be7fe83dR56-R70)

### Version update

* Bumped the package version from `1.4.3` to `1.4.4` in `version.json`.