### PR TITLE
Update to .NET 10

### DIFF
--- a/src/Coderynx.Functional.Orleans/Coderynx.Functional.Orleans.csproj
+++ b/src/Coderynx.Functional.Orleans/Coderynx.Functional.Orleans.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Coderynx.Functional.Orleans</PackageId>
@@ -21,6 +21,9 @@
     <ItemGroup>
         <PackageReference Include="Coderynx.Functional" Version="1.7.11"/>
         <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.2.1"/>
+        <PackageReference Update="Nerdbank.GitVersioning">
+          <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.Functional.WebApi/Coderynx.Functional.WebApi.csproj
+++ b/src/Coderynx.Functional.WebApi/Coderynx.Functional.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Coderynx.Functional.WebApi</PackageId>
@@ -24,6 +24,9 @@
 
     <ItemGroup>
         <PackageReference Include="Coderynx.Functional" Version="1.7.11"/>
+        <PackageReference Update="Nerdbank.GitVersioning">
+          <Version>3.9.50</Version>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.Functional/Coderynx.Functional.csproj
+++ b/src/Coderynx.Functional/Coderynx.Functional.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Coderynx.Functional</PackageId>
@@ -16,6 +16,12 @@
 
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath=""/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Update="Nerdbank.GitVersioning">
+        <Version>3.9.50</Version>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Coderynx.Functional/version.json
+++ b/src/Coderynx.Functional/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.7.11",
+  "version": "1.8.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/tests/Coderynx.Functional.Tests/Coderynx.Functional.Tests.csproj
+++ b/tests/Coderynx.Functional.Tests/Coderynx.Functional.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -13,11 +13,14 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="Nerdbank.GitVersioning">
+          <Version>3.9.50</Version>
         </PackageReference>
     </ItemGroup>
 

--- a/tests/Coderynx.Functional.WebApi.Tests/Coderynx.Functional.WebApi.Tests.csproj
+++ b/tests/Coderynx.Functional.WebApi.Tests/Coderynx.Functional.WebApi.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -13,11 +13,14 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="Nerdbank.GitVersioning">
+          <Version>3.9.50</Version>
         </PackageReference>
     </ItemGroup>
 


### PR DESCRIPTION
This pull request updates all projects in the repository to target .NET 10.0, upgrades several test dependencies, and standardizes the use of the `Nerdbank.GitVersioning` package across all projects. It also bumps the main package version to 1.8.0.

**Target framework and versioning updates:**

* All project files now target `net10.0` instead of `net9.0`, ensuring compatibility with the latest .NET runtime. [[1]](diffhunk://#diff-c4a8c4bd36f7c2d4b84c6e9b992607cfb4bbe523a48825bdd3f85751fbb651a6L4-R4) [[2]](diffhunk://#diff-e808d5fcca1da64bb2e718b45741d48415cd8de4b9c673f4ce79862f2338bec1L4-R4) [[3]](diffhunk://#diff-5b5e2c4543812bbe54c556696487c112ea3f15bbcdffad15784c65495fa81dccL4-R4) [[4]](diffhunk://#diff-d5ad09f8653b9794b5e3f78d03424afdb5bf4a591bbd42f4b247b76c0c8b2577L4-R4) [[5]](diffhunk://#diff-8d117b98a6fc825c7cfc70ff5179a6696ce08e095a5f1a7a267805e16b7ebd9eL4-R4)
* The main package version in `version.json` is updated from 1.7.11 to 1.8.0.

**Dependency and tooling upgrades:**

* The `Nerdbank.GitVersioning` package is now referenced (or updated) to version 3.9.50 in all project files for consistent versioning management. [[1]](diffhunk://#diff-c4a8c4bd36f7c2d4b84c6e9b992607cfb4bbe523a48825bdd3f85751fbb651a6R24-R26) [[2]](diffhunk://#diff-e808d5fcca1da64bb2e718b45741d48415cd8de4b9c673f4ce79862f2338bec1R27-R29) [[3]](diffhunk://#diff-5b5e2c4543812bbe54c556696487c112ea3f15bbcdffad15784c65495fa81dccR21-R26) [[4]](diffhunk://#diff-d5ad09f8653b9794b5e3f78d03424afdb5bf4a591bbd42f4b247b76c0c8b2577L16-R24) [[5]](diffhunk://#diff-8d117b98a6fc825c7cfc70ff5179a6696ce08e095a5f1a7a267805e16b7ebd9eL16-R24)
* Test projects update `Microsoft.NET.Test.Sdk` to 18.0.1 and `xunit.runner.visualstudio` to 3.1.5, ensuring up-to-date tooling for testing. [[1]](diffhunk://#diff-d5ad09f8653b9794b5e3f78d03424afdb5bf4a591bbd42f4b247b76c0c8b2577L16-R24) [[2]](diffhunk://#diff-8d117b98a6fc825c7cfc70ff5179a6696ce08e095a5f1a7a267805e16b7ebd9eL16-R24)