### PR TITLE
Update GitHub workflows to use .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/release-nuget-package.yml
+++ b/.github/workflows/release-nuget-package.yml
@@ -15,7 +15,7 @@ on:
         description: '.NET version to use'
         required: false
         type: string
-        default: '9.x'
+        default: '10.x'
     secrets:
       NUGET_API_KEY:
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       project-path: ${{ matrix.project-path }}
       project-name: ${{ matrix.project-name }}
-      dotnet-version: '9.x'
+      dotnet-version: '10.x'
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     strategy:


### PR DESCRIPTION
This pull request updates our CI and release workflows to use .NET 10 instead of .NET 9. The changes ensure that all automated builds and releases are run against the latest major version of .NET, keeping our tooling up to date.

**CI/CD pipeline updates:**

* Updated the `dotnet-version` in `.github/workflows/ci.yml` from `9.x` to `10.x`, so all CI builds now use .NET 10.
* Changed the default `dotnet-version` input in `.github/workflows/release-nuget-package.yml` from `9.x` to `10.x` to ensure NuGet package releases use .NET 10 by default.
* Updated the `dotnet-version` in `.github/workflows/release.yml` from `9.x` to `10.x` to align release builds with the latest .NET version.