### PR TITLE
Update `Coderynx.Functional` to v1.8.0 and bump project versions to 1.8.0

### DIFF
--- a/src/Coderynx.Functional.Orleans/Coderynx.Functional.Orleans.csproj
+++ b/src/Coderynx.Functional.Orleans/Coderynx.Functional.Orleans.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.Functional" Version="1.7.11"/>
+        <PackageReference Include="Coderynx.Functional" Version="1.8.0" />
         <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.2.1"/>
         <PackageReference Update="Nerdbank.GitVersioning">
           <Version>3.9.50</Version>

--- a/src/Coderynx.Functional.Orleans/version.json
+++ b/src/Coderynx.Functional.Orleans/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.6",
+  "version": "1.8.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/src/Coderynx.Functional.WebApi/Coderynx.Functional.WebApi.csproj
+++ b/src/Coderynx.Functional.WebApi/Coderynx.Functional.WebApi.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Coderynx.Functional" Version="1.7.11"/>
+        <PackageReference Include="Coderynx.Functional" Version="1.8.0" />
         <PackageReference Update="Nerdbank.GitVersioning">
           <Version>3.9.50</Version>
         </PackageReference>

--- a/src/Coderynx.Functional.WebApi/version.json
+++ b/src/Coderynx.Functional.WebApi/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.4",
+  "version": "1.8.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
This pull request updates both the `Coderynx.Functional.Orleans` and `Coderynx.Functional.WebApi` projects to use version 1.8.0 of the `Coderynx.Functional` package and synchronizes their version numbers to 1.8.0. These changes ensure consistency and compatibility across the projects.

Dependency updates:

* Updated the `Coderynx.Functional` package reference to version 1.8.0 in both `Coderynx.Functional.Orleans.csproj` and `Coderynx.Functional.WebApi.csproj` files. [[1]](diffhunk://#diff-c4a8c4bd36f7c2d4b84c6e9b992607cfb4bbe523a48825bdd3f85751fbb651a6L22-R22) [[2]](diffhunk://#diff-e808d5fcca1da64bb2e718b45741d48415cd8de4b9c673f4ce79862f2338bec1L26-R26)

Versioning:

* Updated the version numbers to 1.8.0 in both `Coderynx.Functional.Orleans/version.json` and `Coderynx.Functional.WebApi/version.json` for release alignment.